### PR TITLE
Update portable.nsi

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/portable.nsi
+++ b/packages/electron-builder-lib/templates/nsis/portable.nsi
@@ -18,16 +18,16 @@ Section
 	!ifdef APP_DIR_64
     !ifdef APP_DIR_32
       ${if} ${RunningX64}
-        File /r "${APP_DIR_64}/*.*"
+        File /r "${APP_DIR_64}\*.*"
       ${else}
-        File /r "${APP_DIR_32}/*.*"
+        File /r "${APP_DIR_32}\*.*"
       ${endIf}
     !else
-      File /r "${APP_DIR_64}/*.*"
+      File /r "${APP_DIR_64}\*.*"
     !endif
   !else
     !ifdef APP_DIR_32
-      File /r "${APP_DIR_32}/*.*"
+      File /r "${APP_DIR_32}\*.*"
     !else
       !insertmacro extractEmbeddedAppPackage
     !endif


### PR DESCRIPTION
Building the new zip portable does not like slashes on win:
![image](https://user-images.githubusercontent.com/26599181/37195690-337eb80a-2374-11e8-872d-0a69566fc741.png)
