### PR TITLE
Install openjdk-8 so that invocations of jsign work

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # rpm is required for FPM to build rpm package
   # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
   apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
-  libsecret-1-dev libgnome-keyring-dev \
+  libsecret-1-dev libgnome-keyring-dev openjdk-8-jdk \
   libopenjp2-tools && \
   # git-lfs
   git lfs install && \


### PR DESCRIPTION
I want to use the docker images to build my application, but require openjdk to be installed so that invocations of jsign work.

It would be nice not to have to install it every time I run up the docker image.